### PR TITLE
call setUserAttributes instead of identify if userId is not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ import Drift from 'react-driftjs'
 <Drift appId="xxxxx" />  //get the appId from drift.com
 ```
 
-### Identify User
+### Identify User / Assign Attributes
 
+To identify the user with an ID that is unique in your application, include a userId property with that value. This will trigger the chatbot to use the `identify` method method.  If the userId is omitted, the component will have the chatbot use the `setUserAttributes` method.
 ```javascript
 
 <Drift appId="xxxxx" 
@@ -27,6 +28,23 @@ import Drift from 'react-driftjs'
   attributes={{ email: "user@example.com", company: "Acme Inc" }}
 />
   
+```
+
+### Add Event Handlers
+
+The chatbot widget emits several events. A listing of the events can be found here: https://devdocs.drift.com/docs/drift-events#section-first-interaction
+To handle the events, assign an array of objects to the eventHandlers property. The `event` property will match the name of the event emitted by drift. The `function` property is the function definition of the handler.
+
+``` javascript
+
+<Drift appId="xxxxx"
+  eventHandlers={[{'event': 'conversation:firstInteraction', 'function': handleInteraction}]}
+/>
+
+var handleInteraction = function() {
+    console.log('User has just interacted with the chatbot')
+}
+
 ```
 
 More information can be found here: https://www.drift.com/

--- a/src/Drift.jsx
+++ b/src/Drift.jsx
@@ -6,7 +6,7 @@ class Drift extends React.Component {
     super(props);
 
     this.addMainScript = this.addMainScript.bind(this);
-    this.addIdentityVariables = this.addIdentityVariables.bind(this);
+    this.addAttributes = this.addAttributes.bind(this);
     this.insertScript = this.insertScript.bind(this);
   }
 
@@ -44,13 +44,22 @@ class Drift extends React.Component {
     this.insertScript(scriptText);
   }
 
-  addIdentityVariables() {
+  addAttributes() {
+    let scriptText = ''
     if (typeof this.props.userId !== "undefined") {
-      let scriptText = `
+      scriptText = `
         var t = window.driftt = window.drift = window.driftt || [];
         drift.identify('${this.props.userId}', ${JSON.stringify(
         this.props.attributes
       )})
+      `;
+      this.insertScript(scriptText);
+    }
+    else if(this.props.attributes) {
+      scriptText = `
+        drift.on('ready', function() {
+          drift.api.setUserAttributes(${JSON.stringify(this.props.attributes)})
+        })
       `;
       this.insertScript(scriptText);
     }
@@ -59,7 +68,7 @@ class Drift extends React.Component {
   componentDidMount() {
     if (typeof window !== "undefined" && !window.drift) {
       this.addMainScript();
-      this.addIdentityVariables();
+      this.addAttributes();
     }
   }
 

--- a/src/Drift.jsx
+++ b/src/Drift.jsx
@@ -7,6 +7,7 @@ class Drift extends React.Component {
 
     this.addMainScript = this.addMainScript.bind(this);
     this.addAttributes = this.addAttributes.bind(this);
+    this.addEventHandlers = this.addEventHandlers.bind(this);
     this.insertScript = this.insertScript.bind(this);
   }
 
@@ -65,10 +66,22 @@ class Drift extends React.Component {
     }
   }
 
+  addEventHandlers() {
+    if(this.props.eventHandlers && Array.isArray(this.props.eventHandlers)) {
+      this.props.eventHandlers.forEach(handler => {
+        let scriptText = `
+        drift.on('${handler.event}', ${handler.function});
+        `;
+        this.insertScript(scriptText)
+      });
+    }
+  }
+
   componentDidMount() {
     if (typeof window !== "undefined" && !window.drift) {
       this.addMainScript();
       this.addAttributes();
+      this.addEventHandlers();
     }
   }
 
@@ -79,7 +92,8 @@ class Drift extends React.Component {
 
 const propTypes = {
   appId: PropTypes.string.isRequired,
-  attributes: PropTypes.object
+  attributes: PropTypes.object,
+  eventHandlers: PropTypes.array
 };
 
 Drift.propTypes = propTypes;


### PR DESCRIPTION
Currently, this component requires a userId property to be passed in for attributes to be set for the user.  Firstly, this requirement is undocumented.  Secondly, the component should still set the attributes if the userId is not set.

This PR calls setUserAttributes if the userId is not set.  