### PR TITLE
Added ability to pass in a custom style object

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,21 +13,21 @@ npm install react-driftjs
 ### Usage
 
 ```javascript
-import Drift from 'react-driftjs'
+import Drift from "react-driftjs";
 
-<Drift appId="xxxxx" />  //get the appId from drift.com
+<Drift appId="xxxxx" />; //get the appId from drift.com
 ```
 
 ### Identify User / Assign Attributes
 
-To identify the user with an ID that is unique in your application, include a userId property with that value. This will trigger the chatbot to use the `identify` method method.  If the userId is omitted, the component will have the chatbot use the `setUserAttributes` method.
-```javascript
+To identify the user with an ID that is unique in your application, include a userId property with that value. This will trigger the chatbot to use the `identify` method method. If the userId is omitted, the component will have the chatbot use the `setUserAttributes` method.
 
-<Drift appId="xxxxx" 
+```javascript
+<Drift
+  appId="xxxxx"
   userId="1234"
   attributes={{ email: "user@example.com", company: "Acme Inc" }}
 />
-  
 ```
 
 ### Add Event Handlers
@@ -35,16 +35,30 @@ To identify the user with an ID that is unique in your application, include a us
 The chatbot widget emits several events. A listing of the events can be found here: https://devdocs.drift.com/docs/drift-events#section-first-interaction
 To handle the events, assign an array of objects to the eventHandlers property. The `event` property will match the name of the event emitted by drift. The `function` property is the function definition of the handler.
 
-``` javascript
+```javascript
+<Drift
+  appId="xxxxx"
+  eventHandlers={[
+    { event: "conversation:firstInteraction", function: handleInteraction },
+  ]}
+/>;
 
-<Drift appId="xxxxx"
-  eventHandlers={[{'event': 'conversation:firstInteraction', 'function': handleInteraction}]}
+var handleInteraction = function () {
+  console.log("User has just interacted with the chatbot");
+};
+```
+
+### Add Custom Styles
+
+To add custom styling to the root `<iframe>` element (e.g. to change the position of the chatbot widget) you can assign a style object to the `style` property. This object will be parsed as a css string and added to a style tag in the head of the document.
+
+```javascript
+<Drift
+  appId="xxxxx"
+  style={{
+    bottom: "100px",
+  }}
 />
-
-var handleInteraction = function() {
-    console.log('User has just interacted with the chatbot')
-}
-
 ```
 
 More information can be found here: https://www.drift.com/

--- a/src/Drift.jsx
+++ b/src/Drift.jsx
@@ -9,6 +9,8 @@ class Drift extends React.Component {
     this.addAttributes = this.addAttributes.bind(this);
     this.addEventHandlers = this.addEventHandlers.bind(this);
     this.insertScript = this.insertScript.bind(this);
+    this.createStyleString = this.createStyleString.bind(this);
+    this.addCustomStyle = this.addCustomStyle.bind(this);
   }
 
   insertScript(scriptText) {
@@ -23,7 +25,7 @@ class Drift extends React.Component {
         var t = window.driftt = window.drift = window.driftt || [];
         if (!t.init) {
           if (t.invoked) return void (window.console && console.error && console.error("Drift snippet included twice."));
-          t.invoked = !0, t.methods = [ "identify", "config", "track", "reset", "debug", "show", "ping", "page", "hide", "off", "on", "setUserAttributes" ], 
+          t.invoked = !0, t.methods = [ "identify", "config", "track", "reset", "debug", "show", "ping", "page", "hide", "off", "on", "setUserAttributes" ],
           t.factory = function(e) {
             return function() {
               var n = Array.prototype.slice.call(arguments);
@@ -46,7 +48,7 @@ class Drift extends React.Component {
   }
 
   addAttributes() {
-    let scriptText = ''
+    let scriptText = "";
     if (typeof this.props.userId !== "undefined") {
       scriptText = `
         var t = window.driftt = window.drift = window.driftt || [];
@@ -55,8 +57,7 @@ class Drift extends React.Component {
       )})
       `;
       this.insertScript(scriptText);
-    }
-    else if(this.props.attributes) {
+    } else if (this.props.attributes) {
       scriptText = `
         drift.on('ready', function() {
           drift.api.setUserAttributes(${JSON.stringify(this.props.attributes)})
@@ -67,13 +68,38 @@ class Drift extends React.Component {
   }
 
   addEventHandlers() {
-    if(this.props.eventHandlers && Array.isArray(this.props.eventHandlers)) {
-      this.props.eventHandlers.forEach(handler => {
+    if (this.props.eventHandlers && Array.isArray(this.props.eventHandlers)) {
+      this.props.eventHandlers.forEach((handler) => {
         let scriptText = `
         drift.on('${handler.event}', ${handler.function});
         `;
-        this.insertScript(scriptText)
+        this.insertScript(scriptText);
       });
+    }
+  }
+
+  createStyleString() {
+    return Object.keys(this.props.style).reduce((styleString, styleName) => {
+      const styleValue = this.props.style[styleName];
+
+      styleName = styleName.replace(
+        /[A-Z]/g,
+        (match) => `-${match.toLowerCase()}`
+      );
+
+      return `${styleString}${styleName}: ${styleValue} !important;`;
+    }, "");
+  }
+
+  addCustomStyle() {
+    if (this.props.style) {
+      const style = document.createElement("style");
+      document.head.appendChild(style);
+      style.innerText = `
+        iframe#drift-widget {
+          ${this.createStyleString()}
+        }
+      `;
     }
   }
 
@@ -82,6 +108,7 @@ class Drift extends React.Component {
       this.addMainScript();
       this.addAttributes();
       this.addEventHandlers();
+      this.addCustomStyle();
     }
   }
 
@@ -93,7 +120,8 @@ class Drift extends React.Component {
 const propTypes = {
   appId: PropTypes.string.isRequired,
   attributes: PropTypes.object,
-  eventHandlers: PropTypes.array
+  eventHandlers: PropTypes.array,
+  style: PropTypes.object,
 };
 
 Drift.propTypes = propTypes;


### PR DESCRIPTION
First of all, thanks for the effort you put into making this component!

This PR came from a need we had at work where the widget needs to dynamically change positions based on the existence of a notification bar that may appear at the bottom of the viewport so it's not overlaying and obstructing the content. I realized there wasn't really a straightforward way of doing this with the native Drift script and figured it would be nice to have a `style` interface to   work with. 

(Sorry about the random style fixes. My linter auto-fixed some semicolon inconsistencies. Happy to turn it off and resubmit the PR if that's an issue.)

Example usage:

```
<Drift
  appId="xxxxx"
  style={{
    bottom: "100px",
  }}
/>
```